### PR TITLE
Set schedule layout to `full` for online talks

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,9 +108,7 @@ class Schedule(FrontmatterModel):
     published: bool = False
     room: Optional[str]
     schedule: Optional[str]
-    schedule_layout: Optional[str] = Field(
-        alias="schedule-layout"
-    )  # TODO: Validate for breaks, lunch, etc
+    schedule_layout: Optional[str]  # TODO: Validate for breaks, lunch, etc
     show_video_urls: Optional[bool]
     slides_url: Optional[str]
     summary: Optional[str]
@@ -260,6 +258,10 @@ def main(input_filename: Path, output_folder: Path = None):
                 end_date = parse(raw_end_date).astimezone(CONFERENCE_TZ)
             if start_date and TALK_FORMATS.get(talk_format) == "tutorials":
                 end_date = start_date + TUTORIAL_LENGTH_OVERRIDE
+            room = row["Room"]["en"]
+            kwargs = {}
+            if "Online" in room:
+                kwargs["schedule_layout"] = "full"
             try:
                 data = Schedule(
                     abstract=row["Abstract"],
@@ -281,6 +283,7 @@ def main(input_filename: Path, output_folder: Path = None):
                     date=start_date,
                     end_date=end_date,
                     summary="",
+                    **kwargs,
                     # todo: refactor template layout to support multiple authors,
                     # presenters=row["Speaker names"],
                 )

--- a/main.py
+++ b/main.py
@@ -254,11 +254,11 @@ def main(input_filename: Path, output_folder: Path = None):
             post = frontmatter.loads(row["Description"])
             start_date = None
             end_date = None
-            if raw_start_date := row.get('Start'):
+            if raw_start_date := row.get("Start"):
                 start_date = parse(raw_start_date).astimezone(CONFERENCE_TZ)
-            if raw_end_date := row.get('End'):
+            if raw_end_date := row.get("End"):
                 end_date = parse(raw_end_date).astimezone(CONFERENCE_TZ)
-            if start_date and TALK_FORMATS.get(talk_format) == 'tutorials':
+            if start_date and TALK_FORMATS.get(talk_format) == "tutorials":
                 end_date = start_date + TUTORIAL_LENGTH_OVERRIDE
             try:
                 data = Schedule(


### PR DESCRIPTION
Corollary to https://github.com/djangocon/2022.djangocon.us/pull/93